### PR TITLE
Update fall risk page layout

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -18,128 +18,34 @@ const Nav = ({ active }) => (
         </a>
       </li>
       <li>
-        <a href="#products" className={active === "products" ? "active" : ""}>
-          Products
+        <a href="#need-screen" className={active === "need-screen" ? "active" : ""}>
+          Need to Screen
         </a>
-        <ul>
-          <li>
-            <a href="#fra">Fall Risk Assessment</a>
-            <ul>
-              <li>
-                <a href="#fra">Overview &amp; Benefits</a>
-              </li>
-              <li>
-                <a href="#fra-how">How It Works</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a href="#balance">Balance Training Program</a>
-            <ul>
-              <li>
-                <a href="#balance">Key Features</a>
-              </li>
-              <li>
-                <a href="#balance-video">Sample Exercises / Video Preview</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a href="#safety">Home Safety Toolkit</a>
-            <ul>
-              <li>
-                <a href="#safety">PDF Checklist</a>
-              </li>
-              <li>
-                <a href="#safety">Interactive Online Version</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a href="#telehealth">Telehealth Integration</a>
-            <ul>
-              <li>
-                <a href="#telehealth-features">Platform Features</a>
-              </li>
-              <li>
-                <a href="#telehealth-setup">Technical Requirements</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a href="#pulse">Pulse4Pulse Cardiovascular Assessment</a>
-            <ul>
-              <li>
-                <a href="#p4p-overview">Overview &amp; Mission</a>
-              </li>
-              <li>
-                <a href="#p4p-how">How It Works</a>
-              </li>
-              <li>
-                <a href="#key-tests">Key Tests &amp; Benefits</a>
-              </li>
-              <li>
-                <a href="#eligible-conditions">Eligible Conditions</a>
-              </li>
-              <li>
-                <a href="#practice-benefits">Practice Benefits</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
       </li>
       <li>
-        <a href="#resources" className={active === "resources" ? "active" : ""}>
-          Resources
+        <a href="#fra-overview" className={active === "fra-overview" ? "active" : ""}>
+          What is FRA?
         </a>
-        <ul>
-          <li>
-            <a href="#resources-guides">User Guides</a>
-          </li>
-          <li>
-            <a href="#resources-faq">Troubleshooting FAQs</a>
-          </li>
-          <li>
-            <a href="#resources-infographics">Infographics</a>
-          </li>
-          <li>
-            <a href="#resources-case-studies">Case Studies</a>
-          </li>
-        </ul>
+      </li>
+      <li>
+        <a href="#fra-research" className={active === "fra-research" ? "active" : ""}>
+          FRA Research
+        </a>
+      </li>
+      <li>
+        <a href="#who-we-help" className={active === "who-we-help" ? "active" : ""}>
+          Who We Help
+        </a>
       </li>
       <li>
         <a href="#about" className={active === "about" ? "active" : ""}>
-          About Us
-        </a>
-        <ul>
-          <li>
-            <a href="#about-mission">Mission &amp; Vision</a>
-          </li>
-          <li>
-            <a href="#about-team">Leadership Team</a>
-          </li>
-          <li>
-            <a href="#about-affiliations">Affiliations</a>
-          </li>
-        </ul>
-      </li>
-      <li>
-        <a href="#blog" className={active === "blog" ? "active" : ""}>
-          Blog
+          About
         </a>
       </li>
       <li>
         <a href="#contact" className={active === "contact" ? "active" : ""}>
           Contact
         </a>
-        <ul>
-          <li>
-            <a href="#contact-form">Contact Form</a>
-          </li>
-          <li>
-            <a href="#request-demo">Request a Demo</a>
-          </li>
-        </ul>
       </li>
     </NavLinks>
   </NavBar>

--- a/src/components/sections/About.jsx
+++ b/src/components/sections/About.jsx
@@ -1,14 +1,13 @@
 import React from "react"
-import { Section, SectionTitle, InfoBox, BulletList } from "../styles"
+import { Section, SectionTitle, InfoBox, Paragraph } from "../styles"
 
 const About = () => (
   <Section id="about">
-    <SectionTitle>About Us</SectionTitle>
+    <SectionTitle>About Upright Medical Solutions</SectionTitle>
     <InfoBox>
-      <BulletList>
-        <li>Mission & Vision to reduce falls.</li>
-        <li>Leadership team and key partners.</li>
-      </BulletList>
+      <Paragraph>
+        As a national distributor we offer value base care solutions to our customers that can be beneficial to their patients.
+      </Paragraph>
     </InfoBox>
   </Section>
 )

--- a/src/components/sections/Contact.jsx
+++ b/src/components/sections/Contact.jsx
@@ -4,16 +4,18 @@ import { Section, SectionTitle, ContactForm } from "../styles"
 const Contact = () => (
   <Section id="contact">
     <SectionTitle>Contact</SectionTitle>
+    <p style={{textAlign: 'center', marginBottom: '1rem'}}>
+      <strong>Let’s Talk Fall Prevention.</strong>
+    </p>
+    <p style={{textAlign: 'center', marginBottom: '1rem'}}>
+      Interested in learning more? Contact us for a demo or partnership discussion.
+    </p>
     <ContactForm>
       <input type="text" placeholder="Name" required />
       <input type="email" placeholder="Email" required />
       <textarea rows="4" placeholder="Message"></textarea>
-      <button type="submit">Request Demo</button>
+      <button type="submit">Send</button>
     </ContactForm>
-    <p style={{textAlign: 'center', marginTop: '1rem'}}>
-      123 Wellness Way, Suite 100<br />
-      Anytown, USA &bull; (555) 123-4567
-    </p>
   </Section>
 )
 

--- a/src/components/sections/FraOverview.jsx
+++ b/src/components/sections/FraOverview.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Section, SectionTitle, InfoBox, Paragraph } from "../styles";
+
+const FraOverview = () => (
+  <Section id="fra-overview">
+    <SectionTitle>What is Fall Risk Assessment (FRA)?</SectionTitle>
+    <InfoBox>
+      <Paragraph>
+        (FRA) Fall Risk program will help patients mitigate the risk of falling and help identify the underlying risk factors for potential falls. It will help you create customized plan of care for each patient and enables you track outcomes over multiple assessments. Listed below are some of the features and benefits of this program.
+      </Paragraph>
+    </InfoBox>
+  </Section>
+);
+
+export default FraOverview;

--- a/src/components/sections/FraResearch.jsx
+++ b/src/components/sections/FraResearch.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Section, SectionTitle, InfoBox, Paragraph } from "../styles";
+
+const FraResearch = () => (
+  <Section id="fra-research">
+    <SectionTitle>FRA Research</SectionTitle>
+    <InfoBox>
+      <Paragraph>
+        The webFCE Fall Risk Assessment (FRA) consists of 12 basic evaluative tools that calculate an individual’s risk (and probability) of falling. These measurements were obtained from a comprehensive fall risk “meta-study” that examined over 2,200 fall risk studies and we examined over 12,700 population norm studies found in the literature.
+      </Paragraph>
+      <Paragraph>
+        Utilizing a statistical method of post-test probability each individual measurement will calculate a basic estimation of the probability that a future fall is likely. However, when all twelve tools are combined via complicated mathematical algorithms a much more accurate determination of fall risk is obtained.
+      </Paragraph>
+      <Paragraph>
+        This post-test probability determination ultimately enables the clinician the ability to predict the probability of falls over a 12 month time frame for different diverse populations: healthy young, middle-aged, and older populations.
+      </Paragraph>
+    </InfoBox>
+  </Section>
+);
+
+export default FraResearch;

--- a/src/components/sections/NeedScreen.jsx
+++ b/src/components/sections/NeedScreen.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Section, SectionTitle, InfoBox, Paragraph } from "../styles";
+
+const NeedScreen = () => (
+  <Section id="need-screen">
+    <SectionTitle>Need to Screen</SectionTitle>
+    <InfoBox>
+      <Paragraph>
+        For older adults, falls are serious.
+      </Paragraph>
+      <Paragraph>
+        Each year, millions of seniors suffer a fall. One in five will result in a severe injury such as a broken bone or head injury. In fact, falling is the leading cause of death in older adults.
+      </Paragraph>
+      <Paragraph>
+        If you are at risk of falling, it’s critical for your health and safety to pinpoint your risk and prevent falls from happening.
+      </Paragraph>
+    </InfoBox>
+  </Section>
+);
+
+export default NeedScreen;

--- a/src/components/sections/WhoWeHelp.jsx
+++ b/src/components/sections/WhoWeHelp.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Section, SectionTitle, InfoBox, Paragraph } from "../styles";
+
+const WhoWeHelp = () => (
+  <Section id="who-we-help">
+    <SectionTitle>Who We Help</SectionTitle>
+    <InfoBox>
+      <Paragraph>
+        Upright Medical Solutions Fall Risk platform has provided vital fall-prevention solutions to thousands of Physicians and Healthcare clinics the United States. While our primary focus is the +65 population, there is a growing need for introducing a Fall Risk plan of care for patients with underlying conditions that can contribute to falls. We would welcome the opportunity to discuss the value this Fall Risk program could bring to your practice.
+      </Paragraph>
+    </InfoBox>
+  </Section>
+);
+
+export default WhoWeHelp;

--- a/src/pages/fall-risk.js
+++ b/src/pages/fall-risk.js
@@ -5,15 +5,11 @@ import GlobalStyles from "../components/Layout/GlobalStyles";
 import Nav from "../components/Nav";
 
 import HeroSection from "../components/sections/Hero";
-import ProductsSection from "../components/sections/Products";
-import FallRiskAssessment from "../components/sections/FallRiskAssessment";
-import BalanceTraining from "../components/sections/BalanceTraining";
-import HomeSafety from "../components/sections/HomeSafety";
-import Telehealth from "../components/sections/Telehealth";
-import Pulse4Pulse from "../components/sections/Pulse4Pulse";
-import Resources from "../components/sections/Resources";
+import NeedScreen from "../components/sections/NeedScreen";
+import FraOverview from "../components/sections/FraOverview";
+import FraResearch from "../components/sections/FraResearch";
+import WhoWeHelp from "../components/sections/WhoWeHelp";
 import About from "../components/sections/About";
-import Blog from "../components/sections/Blog";
 import Contact from "../components/sections/Contact";
 
 const FallRiskPage = () => {
@@ -22,15 +18,11 @@ const FallRiskPage = () => {
   useEffect(() => {
     const ids = [
       "hero",
-      "products",
-      "fra",
-      "balance",
-      "safety",
-      "telehealth",
-      "pulse",
-      "resources",
+      "need-screen",
+      "fra-overview",
+      "fra-research",
+      "who-we-help",
       "about",
-      "blog",
       "contact",
     ];
 
@@ -69,32 +61,20 @@ const FallRiskPage = () => {
       {/* ───────────── Hero / Introduction ───────────── */}
       <HeroSection id="hero" />
 
-      {/* ───────────── Products overview ───────────── */}
-      <ProductsSection id="products" />
+      {/* ───────────── Need to Screen ───────────── */}
+      <NeedScreen id="need-screen" />
 
-      {/* ───────────── Fall Risk Assessment ───────────── */}
-      <FallRiskAssessment id="fra" />
+      {/* ───────────── What is FRA ───────────── */}
+      <FraOverview id="fra-overview" />
 
-      {/* ───────────── Balance Training Program ───────────── */}
-      <BalanceTraining id="balance" />
+      {/* ───────────── FRA Research ───────────── */}
+      <FraResearch id="fra-research" />
 
-      {/* ───────────── Home Safety Toolkit ───────────── */}
-      <HomeSafety id="safety" />
+      {/* ───────────── Who We Help ───────────── */}
+      <WhoWeHelp id="who-we-help" />
 
-      {/* ───────────── Telehealth Integration ───────────── */}
-      <Telehealth id="telehealth" />
-
-      {/* ───────────── Pulse4Pulse Cardiovascular Assessment ───────────── */}
-      <Pulse4Pulse id="pulse" />
-
-      {/* ───────────── Resources ───────────── */}
-      <Resources id="resources" />
-
-      {/* ───────────── About Us ───────────── */}
+      {/* ───────────── About ───────────── */}
       <About id="about" />
-
-      {/* ───────────── Blog ───────────── */}
-      <Blog id="blog" />
 
       {/* ───────────── Contact ───────────── */}
       <Contact id="contact" />


### PR DESCRIPTION
## Summary
- replace Products-based navigation with simpler fall risk sections
- add new sections: Need to Screen, FRA Overview, FRA Research, and Who We Help
- update About and Contact copy
- simplify nav menu

## Testing
- `npm run build` *(fails: gatsby permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6852f1287f60832f8a78c98a1fc877df