### PR TITLE
Add About and Contact pages

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import styled from "styled-components";
+
+const FooterWrapper = styled.footer`
+  text-align: center;
+  padding: 2rem;
+  margin-top: 4rem;
+  background: #EAECEF;
+  color: #334D6E;
+`;
+
+const Footer = () => (
+  <FooterWrapper>
+    <p>&copy; {new Date().getFullYear()} Upright Medical Solutions. All Rights Reserved.</p>
+  </FooterWrapper>
+);
+
+export default Footer;

--- a/src/pages/Pulse4Pulse.jsx
+++ b/src/pages/Pulse4Pulse.jsx
@@ -1,7 +1,6 @@
 // File: src/pages/pulse4pulse.jsx
 
 import React from "react";
-import styled from "styled-components";
 import GlobalStyles from "../components/Layout/GlobalStyles"; // Import GlobalStyles
 import Nav from "../components/Nav";
 import PulseHero from "../components/sections/PulseHero";
@@ -14,15 +13,9 @@ import PulseBenefits from "../components/sections/PulseBenefits";
 import PulseSpecialties from "../components/sections/PulseSpecialties";
 import About from "../components/sections/About";
 import Contact from "../components/sections/Contact";
+import Footer from "../components/Footer";
 
-// A simple styled footer for this page
-const Footer = styled.footer`
-  text-align: center;
-  padding: 2rem;
-  margin-top: 4rem;
-  background: #EAECEF;
-  color: #334D6E;
-`;
+// Reuse the shared footer styling
 
 const Pulse4Pulse = () => (
   <>
@@ -40,9 +33,7 @@ const Pulse4Pulse = () => (
       <About />
       <Contact isPulsePage={true} />
     </main>
-    <Footer>
-      <p>&copy; {new Date().getFullYear()} Upright Medical Solutions. All Rights Reserved.</p>
-    </Footer>
+    <Footer />
   </>
 );
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,0 +1,23 @@
+import React from "react";
+import styled from "styled-components";
+import GlobalStyles from "../components/Layout/GlobalStyles";
+import Nav from "../components/Nav";
+import AboutSection from "../components/sections/About";
+import Footer from "../components/Footer";
+
+const Main = styled.main`
+  padding-top: 2rem;
+`;
+
+const AboutPage = () => (
+  <>
+    <GlobalStyles />
+    <Nav active="about" />
+    <Main>
+      <AboutSection />
+    </Main>
+    <Footer />
+  </>
+);
+
+export default AboutPage;

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,0 +1,23 @@
+import React from "react";
+import styled from "styled-components";
+import GlobalStyles from "../components/Layout/GlobalStyles";
+import Nav from "../components/Nav";
+import ContactSection from "../components/sections/Contact";
+import Footer from "../components/Footer";
+
+const Main = styled.main`
+  padding-top: 2rem;
+`;
+
+const ContactPage = () => (
+  <>
+    <GlobalStyles />
+    <Nav active="contact" />
+    <Main>
+      <ContactSection />
+    </Main>
+    <Footer />
+  </>
+);
+
+export default ContactPage;


### PR DESCRIPTION
## Summary
- add reusable `Footer` component
- create standalone `about` and `contact` pages
- use shared footer on `Pulse4Pulse` page for consistent styling

## Testing
- `npm run build` *(fails: No native build was found for `@lmdb/lmdb-linux-x64`)*

------
https://chatgpt.com/codex/tasks/task_e_68753ae501d0832fa38884e7962ef1c8