### PR TITLE
Add responsive hamburger navigation

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,21 +1,48 @@
 // File: src/components/Nav.jsx
 
-import React from "react";
-import { NavBar, NavLinks, LogoWrapper } from "./styles";
+import React, { useState } from "react";
+import { NavBar, NavLinks, LogoWrapper, Hamburger } from "./styles";
 
-const Nav = ({ active }) => (
-  <NavBar>
-    <LogoWrapper>
-      {/* This link now correctly points to the top of the home page */}
-      <a href="/">
-        <img
-          src="/images/Upright Medical Solutions Logo.png"
-          alt="Upright Medical Solutions"
-        />
-      </a>
-    </LogoWrapper>
+const Nav = ({ active }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [productsOpen, setProductsOpen] = useState(false);
 
-    <NavLinks>
+  const toggleMenu = () => {
+    setMenuOpen((prev) => !prev);
+    if (menuOpen) {
+      setProductsOpen(false);
+    }
+  };
+
+  const closeMenu = () => {
+    setMenuOpen(false);
+    setProductsOpen(false);
+  };
+
+  return (
+    <NavBar>
+      <LogoWrapper>
+        {/* This link now correctly points to the top of the home page */}
+        <a href="/" onClick={closeMenu}>
+          <img
+            src="/images/Upright Medical Solutions Logo.png"
+            alt="Upright Medical Solutions"
+          />
+        </a>
+      </LogoWrapper>
+
+      <Hamburger
+        onClick={toggleMenu}
+        className={menuOpen ? "open" : ""}
+        aria-label="Toggle navigation"
+        aria-expanded={menuOpen}
+      >
+        <span />
+        <span />
+        <span />
+      </Hamburger>
+
+      <NavLinks className={menuOpen ? "open" : ""}>
       <li>
         {/* The "Home" link also points to the top of the home page */}
         <a href="/" className={active === "home" ? "active" : ""}>
@@ -23,23 +50,23 @@ const Nav = ({ active }) => (
         </a>
       </li>
 
-      <li className="dropdown">
-        <a
-          href="#"
+      <li className={`dropdown ${productsOpen ? "open" : ""}`}>
+        <button
+          onClick={() => setProductsOpen((prev) => !prev)}
           className={`dropdown-toggle ${active === "fall-risk" || active === "pulse4pulse" ? "active" : ""}`}
         >
           Products
-        </a>
+        </button>
         <ul className="dropdown-menu">
           <li>
             {/* This link navigates to the top of the Fall Risk page */}
-            <a href="/fall-risk" className={active === "fall-risk" ? "active" : ""}>
+            <a href="/fall-risk" onClick={closeMenu} className={active === "fall-risk" ? "active" : ""}>
               Fall Risk
             </a>
           </li>
           <li>
             {/* This link navigates to the top of the Pulse4Pulse page */}
-            <a href="/Pulse4Pulse" className={active === "pulse4pulse" ? "active" : ""}>
+            <a href="/Pulse4Pulse" onClick={closeMenu} className={active === "pulse4pulse" ? "active" : ""}>
               Pulse4Pulse
             </a>
           </li>
@@ -48,18 +75,19 @@ const Nav = ({ active }) => (
 
       <li>
         {/* This correctly links to the "About" section on the home page */}
-        <a href="/#about" className={active === "about" ? "active" : ""}>
+        <a href="/#about" onClick={closeMenu} className={active === "about" ? "active" : ""}>
           About
         </a>
       </li>
       <li>
         {/* This correctly links to the "Contact" section on the home page */}
-        <a href="/#contact" className={active === "contact" ? "active" : ""}>
+        <a href="/#contact" onClick={closeMenu} className={active === "contact" ? "active" : ""}>
           Contact
         </a>
       </li>
     </NavLinks>
   </NavBar>
-);
+  );
+};
 
 export default Nav;

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -25,6 +25,12 @@ export const NavBar = styled.nav`
   flex-direction: column;
   align-items: center;
   padding-bottom: 0.5rem;
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 0.5rem 2rem;
+  }
 `;
 
 
@@ -43,6 +49,46 @@ export const LogoWrapper = styled.div`
       height: 140px;
     }
   }
+
+  @media (min-width: 768px) {
+    margin: 0;
+  }
+`;
+
+export const Hamburger = styled.button`
+  display: none;
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  cursor: pointer;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+
+  span {
+    display: block;
+    width: 24px;
+    height: 2px;
+    background: ${COLORS.darkBlue};
+    margin: 5px 0;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+
+  &.open span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+
+  &.open span:nth-child(2) {
+    opacity: 0;
+  }
+
+  &.open span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+
+  @media (max-width: 768px) {
+    display: block;
+  }
 `;
 
 export const NavLinks = styled.ul`
@@ -52,6 +98,13 @@ export const NavLinks = styled.ul`
   margin: 0;
   padding: 0.5rem 1rem;
   position: relative;
+
+  @media (min-width: 768px) {
+    margin-left: auto;
+    flex-direction: row;
+    position: static;
+    height: auto;
+  }
 
   > li {
     position: relative;


### PR DESCRIPTION
## Summary
- implement hamburger navigation component
- allow dropdown toggling in Nav
- adjust navigation styling for mobile and desktop

## Testing
- `npm run build` *(fails: `gatsby build` UNKNOWN)*

------
https://chatgpt.com/codex/tasks/task_e_68754fe1fc44832faf5f6740d516d990