### PR TITLE
Improve responsive design

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Upright Medical Solutions</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/src/components/Layout/GlobalStyles.jsx
+++ b/src/components/Layout/GlobalStyles.jsx
@@ -5,18 +5,21 @@ export default createGlobalStyle`
   *, *::before, *::after {
     box-sizing: border-box;
     margin: 0;
-    padding: 50;
+    padding: 0;
   }
 
   html {
     scroll-behavior: smooth;
+    font-size: 16px;
   }
 
+  /* Base body styles with fluid font size */
   body {
     font-family: 'Inter', sans-serif;
     background: #F7F9FA;
     color: #0A2640;
     line-height: 1.5;
+    font-size: clamp(1rem, 2vw, 1.125rem);
   }
 
   a {

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,65 +1,50 @@
 // File: src/components/Nav.jsx
 
-import React from "react";
-import { NavBar, NavLinks, LogoWrapper } from "./styles";
+import React, { useState } from "react";
+import { FaBars } from "react-icons/fa";
+import { NavBar, NavLinks, LogoWrapper, HamburgerButton } from "./styles";
 
-const Nav = ({ active }) => (
-  <NavBar>
-    <LogoWrapper>
-      {/* This link now correctly points to the top of the home page */}
-      <a href="/">
-        <img
-          src="/images/Upright Medical Solutions Logo.png"
-          alt="Upright Medical Solutions"
-        />
-      </a>
-    </LogoWrapper>
+const Nav = ({ active }) => {
+  const [open, setOpen] = useState(false);
+  const toggleMenu = () => setOpen(!open);
 
-    <NavLinks>
-      <li>
-        {/* The "Home" link also points to the top of the home page */}
-        <a href="/" className={active === "home" ? "active" : ""}>
-          Home
+  return (
+    <NavBar>
+      <LogoWrapper>
+        <a href="/">
+          <img src="/images/Upright Medical Solutions Logo.png" alt="Upright Medical Solutions" />
         </a>
-      </li>
+      </LogoWrapper>
 
-      <li className="dropdown">
-        <a
-          href="#"
-          className={`dropdown-toggle ${active === "fall-risk" || active === "pulse4pulse" ? "active" : ""}`}
-        >
-          Products
-        </a>
-        <ul className="dropdown-menu">
-          <li>
-            {/* This link navigates to the top of the Fall Risk page */}
-            <a href="/fall-risk" className={active === "fall-risk" ? "active" : ""}>
-              Fall Risk
-            </a>
-          </li>
-          <li>
-            {/* This link navigates to the top of the Pulse4Pulse page */}
-            <a href="/Pulse4Pulse" className={active === "pulse4pulse" ? "active" : ""}>
-              Pulse4Pulse
-            </a>
-          </li>
-        </ul>
-      </li>
+      {/* Hamburger for mobile */}
+      <HamburgerButton onClick={toggleMenu} aria-label="Toggle navigation">
+        <FaBars size={24} />
+      </HamburgerButton>
 
-      <li>
-        {/* This correctly links to the "About" section on the home page */}
-        <a href="/about" className={active === "about" ? "active" : ""}>
-          About
-        </a>
-      </li>
-      <li>
-        {/* This correctly links to the "Contact" section on the home page */}
-        <a href="/#contact" className={active === "contact" ? "active" : ""}>
-          Contact
-        </a>
-      </li>
-    </NavLinks>
-  </NavBar>
-);
+      <NavLinks className={open ? "open" : ""}>
+        <li>
+          <a href="/" className={active === "home" ? "active" : ""}>Home</a>
+        </li>
+        <li className="dropdown">
+          <a href="#" className={`dropdown-toggle ${active === "fall-risk" || active === "pulse4pulse" ? "active" : ""}`}>Products</a>
+          <ul className="dropdown-menu">
+            <li>
+              <a href="/fall-risk" className={active === "fall-risk" ? "active" : ""}>Fall Risk</a>
+            </li>
+            <li>
+              <a href="/Pulse4Pulse" className={active === "pulse4pulse" ? "active" : ""}>Pulse4Pulse</a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a href="/about" className={active === "about" ? "active" : ""}>About</a>
+        </li>
+        <li>
+          <a href="/#contact" className={active === "contact" ? "active" : ""}>Contact</a>
+        </li>
+      </NavLinks>
+    </NavBar>
+  );
+};
 
 export default Nav;

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -13,6 +13,16 @@ export const COLORS = {
   lightBg: "#F9FAFB",
 };
 
+// Responsive breakpoints
+// Mobile: < 640px
+// Tablet: 640px – 1023px
+// Desktop: >= 1024px
+export const device = {
+  mobile: "(max-width: 639px)",
+  tablet: "(min-width: 640px) and (max-width: 1023px)",
+  desktop: "(min-width: 1024px)",
+};
+
 
 export const NavBar = styled.nav`
   position: sticky;
@@ -22,9 +32,14 @@ export const NavBar = styled.nav`
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   z-index: 200;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  padding-bottom: 0.5rem;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+
+  /* Tablet layout wraps nav items */
+  @media ${device.tablet} {
+    flex-wrap: wrap;
+  }
 `;
 
 
@@ -42,6 +57,22 @@ export const LogoWrapper = styled.div`
     img {
       height: 140px;
     }
+  }
+`;
+
+// Button for mobile nav toggle
+export const HamburgerButton = styled.button`
+  background: none;
+  border: none;
+  display: none;
+  cursor: pointer;
+
+  @media ${device.mobile} {
+    display: block;
+  }
+
+  &:focus {
+    outline: 2px solid ${COLORS.teal};
   }
 `;
 
@@ -112,7 +143,8 @@ export const NavLinks = styled.ul`
     left: 100%;
   }
 
-  @media (max-width: 768px) {
+  /* Mobile slide-out menu */
+  @media ${device.mobile} {
     flex-direction: column;
     align-items: flex-start;
     position: fixed;
@@ -151,8 +183,18 @@ export const NavLinks = styled.ul`
 export const Section = styled.section`
   max-width: 1100px;
   margin: 5rem auto;
-  padding: 2rem 1.5rem;
-  scroll-margin-top: 200px; 
+  padding: 2rem;
+  scroll-margin-top: 200px;
+
+  /* Adjust padding on tablet */
+  @media ${device.tablet} {
+    padding: 1.5rem;
+  }
+
+  /* Mobile gets the smallest padding */
+  @media ${device.mobile} {
+    padding: 1rem;
+  }
 `;
 
 export const SectionTitle = styled.h2`
@@ -422,11 +464,11 @@ export const FeatureGrid = styled.div`
 
   grid-template-columns: 1fr;
 
-  @media (min-width: 600px) {
+  @media ${device.tablet} {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media (min-width: 992px) {
+  @media ${device.desktop} {
     grid-template-columns: repeat(4, 1fr);
   }
 `;
@@ -493,9 +535,17 @@ export const MethodologyContainer = styled.div`
 
 export const ProcessStepper = styled.div`
   display: grid;
-  /* This now defaults to 3 columns and will not change on smaller screens */
+  /* Desktop shows 3 columns; stack on smaller devices */
   grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
+
+  @media ${device.tablet} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media ${device.mobile} {
+    grid-template-columns: 1fr;
+  }
 `;
 
 export const ProcessStep = styled.div`
@@ -634,6 +684,11 @@ export const TeamGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 2rem;
+
+  /* Ensure single column on small screens */
+  @media ${device.mobile} {
+    grid-template-columns: 1fr;
+  }
 `;
 
 export const TeamMemberCard = styled.div`
@@ -684,7 +739,8 @@ export const ContactLayout = styled.div`
   gap: 3rem;
   margin-top: 3rem;
 
-  @media (max-width: 820px) {
+  /* Stack columns on mobile */
+  @media ${device.mobile} {
     grid-template-columns: 1fr;
   }
 `;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,8 @@ import {
   HeroButton,
   HeroVideo,
   BackgroundVideo,
-  HeroContent
+  HeroContent,
+  device
 } from "../components/styles";
 
 // Styled-components for the product section
@@ -20,6 +21,15 @@ const ProductGrid = styled.div`
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 2rem;
   margin-top: 3rem;
+
+  /* Two columns on tablet, single on mobile */
+  @media ${device.tablet} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media ${device.mobile} {
+    grid-template-columns: 1fr;
+  }
 `;
 
 const ProductCard = styled.div`


### PR DESCRIPTION
## Summary
- add meta viewport to static index.html
- implement mobile hamburger navigation
- define breakpoints and responsive styles
- adjust section padding across breakpoints
- add fluid typography and global cleanup

## Testing
- `npm run build` *(fails: Gatsby not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_687824080c30832fbdde4cb68172fdfd