### PR TITLE
Add global Google tag

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,21 @@
+const React = require("react")
+
+exports.onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <React.Fragment key="gtag">
+      {/* Google tag (gtag.js) */}
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-PRRKEY5NP8"></script>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-PRRKEY5NP8');
+        `,
+        }}
+      />
+    </React.Fragment>,
+  ])
+}


### PR DESCRIPTION
## Summary
- insert Google analytics snippet after the `<head>` element for all pages via `gatsby-ssr.js`

## Testing
- `node node_modules/gatsby-cli/cli.js build` *(fails: No native build was found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688928ec6c58832f8c97b75093ff4941