### PR TITLE
Integrate Google Tag Manager

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,19 @@
 const React = require("react")
 
-exports.onRenderBody = ({ setHeadComponents }) => {
+exports.onRenderBody = ({ setHeadComponents, setPreBodyComponents }) => {
   setHeadComponents([
+    <script
+      key="gtm-script"
+      dangerouslySetInnerHTML={{
+        __html: `
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-WGJP69ZR');
+        `,
+      }}
+    />,
     <React.Fragment key="gtag">
       {/* Google tag (gtag.js) */}
       <script async src="https://www.googletagmanager.com/gtag/js?id=G-PRRKEY5NP8"></script>
@@ -17,5 +29,16 @@ exports.onRenderBody = ({ setHeadComponents }) => {
         }}
       />
     </React.Fragment>,
+  ])
+
+  setPreBodyComponents([
+    <noscript key="gtm-noscript">
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-WGJP69ZR"
+        height="0"
+        width="0"
+        style={{ display: "none", visibility: "hidden" }}
+      />
+    </noscript>,
   ])
 }


### PR DESCRIPTION
## Summary
- embed Google Tag Manager script in page head
- add GTM noscript iframe immediately after opening body tag

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: gatsby: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68924e967f2c832f8039c568516cf2ae